### PR TITLE
Complete hyperreduction of MFP-1

### DIFF
--- a/code/src/romtime/pod.py
+++ b/code/src/romtime/pod.py
@@ -4,7 +4,7 @@ from scipy.linalg import svd
 DROP_TOLERANCE = 1e-8
 
 
-def orth(snapshots, num=None, tol=None):
+def orth(snapshots, num=None, tol=None, orthogonalize=True):
     """Compute orthogonalization via SVD.
 
     Parameters
@@ -28,11 +28,14 @@ def orth(snapshots, num=None, tol=None):
         raise ValueError("You should use an array, not a list.")
 
     # L2 normalization
-    l2_norms = np.linalg.norm(snapshots, axis=0)
-    snap_unit = np.divide(snapshots, l2_norms)
+    if orthogonalize == True:
+        l2_norms = np.linalg.norm(snapshots, axis=0)
+        _snapshots = np.divide(snapshots, l2_norms)
+    else:
+        _snapshots = snapshots
 
     # SVD compression
-    u, s, _ = svd(snap_unit, full_matrices=False)
+    u, s, _ = svd(_snapshots, full_matrices=False)
 
     #  Clean noisy basis vectors
     u = u[:, s > DROP_TOLERANCE]

--- a/code/src/romtime/rom/base.py
+++ b/code/src/romtime/rom/base.py
@@ -15,11 +15,10 @@ class Reductor:
         self.grid = grid
 
         self.mu_space = {self.OFFLINE: list(), self.ONLINE: list()}
-        self.random_state = None
-
         self.report = dict()
-
         self.errors_rom = defaultdict(list)
+
+        self.random_state = None
 
     def _compute_error(self, u, ue):
 

--- a/code/src/romtime/rom/deim.py
+++ b/code/src/romtime/rom/deim.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 from .base import Reductor
 
 
-def _create_basis_vector(size, index):
+def basis_vector(size, index):
     ej = np.zeros((size, 1))
     ej[index, 0] = 1.0
 
@@ -17,6 +17,7 @@ class DiscreteEmpiricalInterpolation(Reductor):
 
     FOM = "fom"
     ROM = "rom"
+    TYPE = "DEIM"
 
     def __init__(
         self,
@@ -31,18 +32,24 @@ class DiscreteEmpiricalInterpolation(Reductor):
 
         Parameters
         ----------
-        assemble : OnedimensionalSolver.assemble_XXX-like method
-            Method to call to obtain the inteporlation cell values.
+        assemble : OneDimensionalSolver.assemble-like method
+            Method to call to obtain the interpolation cell values.
         snapshots : np.array
         basis : np.array
 
         Attributes
         ----------
+        assemble : OneDimensionalSolver.assemble-like method
+        Nh : int
+        N : int
+            Collateral basis size.
+        N_V : int
+            Projection basis size
         snapshots : np.array
-        assemble : OnedimensionalSolver.assemble-like method
-        Vf : np.array
+        Vfh : np.array
+        VfN : np.array
         sigmas : np.array
-        dofs : list
+        dofs : list of tuples
         """
 
         super().__init__(grid=grid)
@@ -62,14 +69,15 @@ class DiscreteEmpiricalInterpolation(Reductor):
 
         self.tree_walk_params = tree_walk_params
 
-        self.N = None
+        self.Nh = int
+        self.N = int
+        self.N_V = int  # Projection basis size
         self.VfN = None
-        self.P = None  # Selector matrix
         self.PT_U = None  # Interpolation matrix
-        self.sigmas = None
-        self.dofs = None
+        self.sigmas = list
+        self.dofs = list
 
-    def run(self, num_pod=None, tol_pod=None):
+    def run(self, orthogonalize=True, num_pod=None, tol_pod=None):
         """Create all the structures necessary for DEIM.
 
         Parameters
@@ -78,29 +86,43 @@ class DiscreteEmpiricalInterpolation(Reductor):
             Number of basis vectors to collect from the snapshots.
         """
 
-        if self.snapshots is not None:
-            Vfh, sigmas = self.snapshots_to_basis(num=num_pod, tol=tol_pod)
+        if self.Vfh is None:
+            # No snapshots, no basis, perform tree walk
+            if self.snapshots is None:
+                params = self.tree_walk_params
+                assert params is not None, "Please provide tree-walk parameters."
+
+                Vfh, sigmas = self.perform_tree_walk(
+                    **params, orthogonalize=orthogonalize
+                )
+            else:
+                Vfh, sigmas = self.compress_snapshots(num=num_pod, tol=tol_pod)
+
+            # Store basis and spectrum
             self.Vfh = Vfh
             self.sigmas = sigmas
 
-        # No snapshots, no basis, perform tree walk
-        elif (self.snapshots is None) & (self.Vfh is None):
-
-            params = self.tree_walk_params
-            assert params is not None, "Please provide tree-walk parameters."
-
-            Vfh, sigmas = self.generate_basis_tree_walk(**params)
-            self.Vfh = Vfh
-            self.sigmas = sigmas
-
+        self.Nh = self.Vfh.shape[0]
         self.N = self.Vfh.shape[1]
 
-        dofs, P = self.determine_interpolation_mesh()
-        self.dofs = dofs
-        self.P = P
+        dofs, P = self.build_interpolation_mesh()
+
+        self.store_dofs(dofs)
 
         # Store interpolation matrix
         self.PT_U = np.matmul(P.T, self.Vfh)
+
+        # Clean-up
+        del P
+
+    def store_dofs(self, dofs):
+        """Store vector entries.
+
+        Parameters
+        ----------
+        dofs : list of ints
+        """
+        self.dofs = [(dof,) for dof in dofs]
 
     def evaluate(self, num, ts):
         """Evaluate online interpolation.
@@ -116,60 +138,162 @@ class DiscreteEmpiricalInterpolation(Reductor):
         sampler_test = self.build_sampling_space(num=num)
 
         for mu in tqdm(
-            sampler_test, desc=f"(DEIM-{self.name}-Evaluation) Walk in mu", leave=True
+            sampler_test,
+            desc=f"({self.TYPE}-{self.name}-Evaluation) Walk in mu",
+            leave=True,
         ):
 
             mu_idx, mu = self.add_mu(step=self.ONLINE, mu=mu)
-            for t in tqdm(ts, desc="(DEIM-Evaluation) Walk in time", leave=False):
+            for t in tqdm(
+                ts, desc=f"({self.TYPE}-Evaluation) Walk in time", leave=False
+            ):
 
                 # Exact solution
-                fh = self.assemble(mu=mu, t=t)
-                fh = functional_to_array(fh)
+                fh = self.assemble_snapshot(mu, t)
 
                 #  Compute approximation
-                fh_appr = self.interpolate(mu, t, which=self.FOM)
+                fh_appr = self._interpolate(mu, t, which=self.FOM)
 
                 error = self._compute_error(u=fh_appr, ue=fh)
                 self.errors_rom[mu_idx].append(error)
 
             self.errors_rom[mu_idx] = np.array(self.errors_rom[mu_idx])
 
-    def generate_basis_tree_walk(
-        self, ts, num_snapshots, num_mu=None, num_t=None, tol_mu=None, tol_t=None
+    def _assemble_functional(self, mu, t):
+        """Assemble functional in vector form.
+
+        Parameters
+        ----------
+        mu : dict
+        t : float
+
+        Returns
+        -------
+        fh : np.array
+        """
+        fh = self.assemble(mu=mu, t=t)
+        fh = functional_to_array(fh)
+        return fh
+
+    def perform_tree_walk(
+        self,
+        ts,
+        num_snapshots,
+        orthogonalize=True,
+        num_mu=None,
+        num_t=None,
+        tol_mu=None,
+        tol_t=None,
     ):
+        """Perform a tree walk in the parameter and time space.
+
+        Parameters
+        ----------
+        ts : iterable of floats
+            Time instants to collect.
+        num_snapshots : int
+            Number of parameters to sample.
+        num_mu : int, optional
+            Number of POD basis to take in the mu-branch, by default None
+        num_t : int, optional
+            Number of POD basis to take in the time-branch, by default None
+        tol_mu : float, optional
+            POD tolerance in the mu-branch, by default None
+        tol_t : float, optional
+            POD tolerance in the mu-branch, by default None
+
+        Returns
+        -------
+        basis : np.array
+            Final basis to interpolate the operator.
+        sigmas : np.array
+            Singular value decay.
+        """
 
         sampler = self.build_sampling_space(num=num_snapshots, rnd=self.random_state)
 
         basis_time = []
-        for mu in tqdm(sampler, desc=f"(DEIM-{self.name}) Walk in mu", leave=True):
+        for mu in tqdm(
+            sampler, desc=f"({self.TYPE}-{self.name}) Walk in mu", leave=True
+        ):
 
             idx_mu, mu = self.add_mu(step=self.OFFLINE, mu=mu)
 
-            _basis, sigmas = self._walk_in_time(mu=mu, ts=ts, num=num_t, tol=tol_t)
+            _basis, sigmas = self._walk_in_time(
+                mu=mu,
+                ts=ts,
+                num=num_t,
+                tol=tol_t,
+                orthogonalize=orthogonalize,
+            )
 
             basis_time.append(_basis)
 
         basis_time = np.hstack(basis_time)
-        basis, sigmas = orth(snapshots=basis_time, num=num_mu, tol=tol_t)
+        basis, sigmas = orth(
+            snapshots=basis_time,
+            num=num_mu,
+            tol=tol_t,
+            orthogonalize=orthogonalize,
+        )
 
         return basis, sigmas
 
-    def _walk_in_time(self, mu, ts, num=None, tol=None):
+    def _walk_in_time(self, mu, ts, orthogonalize=True, num=None, tol=None):
+        """Walk in the time-branch of the tree walk.
+
+        Parameters
+        ----------
+        mu : dict
+        ts : iterable of floats
+            Time instants to collect.
+        num : int, optional
+            Number of POD basis to keep, by default None
+        tol : float, optional
+            Tolerance for truncate the POD basis, by default None
+
+        Returns
+        -------
+        basis : np.array
+            Resulting basis from the time walk with a freezed parameter.
+        sigmas : np.array
+            Singular value decay.
+        """
 
         snapshots = []
-        for t in tqdm(ts, desc="(DEIM) Walk in time", leave=False):
+        for t in tqdm(ts, desc=f"({self.TYPE}) Walk in time", leave=False):
 
-            fh = self.assemble(mu=mu, t=t)
-            fh = functional_to_array(fh)
-
-            snapshots.append(fh)
+            op = self.assemble_snapshot(mu, t)
+            snapshots.append(op)
 
         snapshots = np.array(snapshots).T
-        basis, sigmas = orth(snapshots=snapshots, num=num, tol=tol)
+        basis, sigmas = orth(
+            snapshots=snapshots,
+            num=num,
+            tol=tol,
+            orthogonalize=orthogonalize,
+        )
 
         return basis, sigmas
 
-    def interpolate(self, mu, t, which=None):
+    def assemble_snapshot(self, mu, t):
+        """Assemble functional in vector form.
+
+        Parameters
+        ----------
+        mu : dict
+        t : float
+
+        Returns
+        -------
+        fh : np.array
+        """
+
+        fh = self._assemble_functional(mu, t)
+
+        return fh
+
+    def _interpolate(self, mu, t, which=None):
         """Compute functional interpolation for (mu, t) tuple.
 
         Parameters
@@ -191,7 +315,7 @@ class DiscreteEmpiricalInterpolation(Reductor):
 
         # Local assembly on interpolation mesh
         dofs = self.dofs
-        fh_local = self.assemble(mu=mu, t=t, dofs=dofs)
+        fh_local = self.assemble(mu=mu, t=t, entries=dofs)
 
         # Compute interpolation coefficients
         thetas = self.compute_thetas(rhs=fh_local)
@@ -201,6 +325,29 @@ class DiscreteEmpiricalInterpolation(Reductor):
         approximation = np.sum([thetas[i] * Vf[:, i] for i in range(N)], axis=0)
 
         return approximation
+
+    def interpolate(self, mu, t, which=None):
+        """Compute functional interpolation for (mu, t) tuple.
+
+        Parameters
+        ----------
+        mu : dict
+            Parametrization.
+        t : float
+            Time instant.
+
+        Returns
+        -------
+        approximation : np.array
+
+        Notes
+        -----
+        This method is necessary because the interpolation is always
+        carried out in vector form.
+
+        The public interface of the MDEIM returns a CSR matrix.
+        """
+        return self._interpolate(mu=mu, t=t, which=None)
 
     def compute_thetas(self, rhs):
         """Compute interpolation coefficients.
@@ -220,7 +367,7 @@ class DiscreteEmpiricalInterpolation(Reductor):
         thetas = np.linalg.solve(matrix, rhs)
         return thetas
 
-    def snapshots_to_basis(self, num=None, tol=None):
+    def compress_snapshots(self, num=None, tol=None):
         """Build collateral basis via POD compression.
 
         Parameters
@@ -258,7 +405,7 @@ class DiscreteEmpiricalInterpolation(Reductor):
 
         self.VfN = VfN
 
-    def determine_interpolation_mesh(self):
+    def build_interpolation_mesh(self):
         """Generate data for empirical interpolation using DEIM algorithm.
 
         Returns
@@ -273,7 +420,7 @@ class DiscreteEmpiricalInterpolation(Reductor):
         # Warm up
         U = Vf[:, 0]
         dof_1 = np.argmax(np.abs(U))
-        P = _create_basis_vector(size=Nh, index=dof_1)
+        P = basis_vector(size=Nh, index=dof_1)
 
         #  Reshape to have matrix-like shapes
         U = np.reshape(a=U, newshape=(Nh, 1))
@@ -297,7 +444,7 @@ class DiscreteEmpiricalInterpolation(Reductor):
             dof_idx = np.argmax(np.abs(residual))
 
             # Update interpolation basis information
-            e_idx = _create_basis_vector(size=Nh, index=dof_idx)
+            e_idx = basis_vector(size=Nh, index=dof_idx)
             P = np.hstack((P, e_idx))
             U = np.hstack((U, uj))
             interpolation_dofs.append(dof_idx)

--- a/code/src/romtime/rom/mdeim.py
+++ b/code/src/romtime/rom/mdeim.py
@@ -1,0 +1,236 @@
+import numpy as np
+from romtime.rom.deim import DiscreteEmpiricalInterpolation
+from romtime.utils import (
+    bilinear_to_csr,
+    get_nonzero_entries,
+    project_csr,
+    vector_to_csr,
+)
+
+
+class MatrixDiscreteEmpiricalInterpolation(DiscreteEmpiricalInterpolation):
+
+    TYPE = "MDEIM"
+
+    def __init__(
+        self,
+        assemble,
+        name=None,
+        grid=None,
+        tree_walk_params=None,
+        basis=None,
+        snapshots=None,
+    ):
+        """Matrix Discrete Empirical Interpolation Operator.
+
+        Parameters
+        ----------
+        assemble : OneDimensionalSolver.assemble-like method
+            Method to call to obtain the interpolation cell values.
+        snapshots : np.array
+        basis : np.array
+
+        Attributes
+        ----------
+        assemble : OneDimensionalSolver.assemble-like method
+        Nh : int
+        N : int
+            Collateral basis size.
+        N_V : int
+            Projection basis size.
+        snapshots : np.array
+        Vfh : np.array
+        VfN : np.array
+        sigmas : np.array
+        dofs : list of tuples
+        rows : list of ints
+            Rows CSR pattern.
+        cols : list of ints
+            Columns CSR pattern.
+        """
+
+        super().__init__(
+            assemble=assemble,
+            snapshots=snapshots,
+            name=name,
+            grid=grid,
+            tree_walk_params=tree_walk_params,
+            basis=basis,
+        )
+
+        # Matrix topology
+        self.rows = None
+        self.cols = None
+
+    def setup(self, rnd):
+        """Set up reductor and create matrix topology.
+
+        Parameters
+        ----------
+        rnd : int
+            Random seed.
+
+        Creates
+        -------
+        rows : np.array
+        cols : np.array
+        """
+        super().setup(rnd=rnd)
+
+        sampler = self.build_sampling_space(num=1)
+        mu = list(sampler)[0]
+
+        rows, cols = self.get_matrix_topology(mu=mu, t=1.0)
+
+        self.rows = rows
+        self.cols = cols
+
+    def get_entry(self, idx):
+        """Get the row and column entry from the vector form index.
+
+        Parameters
+        ----------
+        idx : int
+            Vector entry in the vector format of the matrix.
+
+        Returns
+        -------
+        row : int
+        col : int
+        """
+        return self.rows[idx], self.cols[idx]
+
+    def store_dofs(self, dofs):
+        """Store matrix entries to interpolate.
+
+        Parameters
+        ----------
+        dofs : list of ints
+        """
+        self.dofs = [self.get_entry(dof) for dof in dofs]
+
+    def get_matrix_topology(self, mu, t):
+        """Get mesh rows and columns arrangement.
+
+        Parameters
+        ----------
+        mu : [type]
+            [description]
+        t : [type]
+            [description]
+
+        Returns
+        -------
+        rows : np.array
+        cols : np.array
+        """
+
+        Ah = self._assemble_matrix(mu, t)
+        rows, cols, _ = get_nonzero_entries(Ah)
+
+        return rows, cols
+
+    def project_basis(self, V):
+        """Project MDEIM basis unto solution reduced basis.
+
+        Parameters
+        ----------
+        V : np.array Nh x N
+            Reduced basis for solution expansion.
+
+        Creates
+        -------
+        self.VfN
+        """
+
+        Vfh = self.Vfh
+        N = self.N
+        self.N_V = V.shape[1]
+
+        VfN = []
+        for basis_idx in range(N):
+
+            mat_as_vec = Vfh[:, basis_idx]
+
+            mat = vector_to_csr(
+                entries=mat_as_vec,
+                rows=self.rows,
+                cols=self.cols,
+            )
+            AN = project_csr(mat, V)
+
+            # Store as a vector, I will reshape when I interpolate
+            AN = AN.flatten()
+            VfN.append(AN)
+
+        VfN = np.array(VfN).T
+        self.VfN = VfN
+
+    def assemble_snapshot(self, mu, t):
+        """Assemble matrix in CSR format.
+
+        Parameters
+        ----------
+        mu : dict
+        t : float
+
+        Returns
+        -------
+        Ah : np.array
+        """
+
+        Ah = self._assemble_matrix(mu, t)
+        Ah.eliminate_zeros()
+
+        return Ah.data
+
+    def _assemble_matrix(self, mu, t):
+        """Assemble matrix and convert to CSR format.
+
+        Parameters
+        ----------
+        mu : dict
+            Parametrization.
+        t : float
+            Time instant.
+
+        Returns
+        -------
+        Ah : scipy.sparse.csr_matrix
+        """
+        Ah = self.assemble(mu=mu, t=t)
+        Ah = bilinear_to_csr(matrix=Ah)
+        return Ah
+
+    def interpolate(self, mu, t, which=None):
+        """Compute operator interpolation for (mu, t) tuple.
+
+        Parameters
+        ----------
+        mu : dict
+            Parametrization.
+        t : float
+            Time instant.
+
+        Returns
+        -------
+        csr_matrix : scipy.sparse.csr_matrix
+        """
+        # Compute vector form interpolation
+        approximation = super()._interpolate(mu, t, which=which)
+
+        if which == self.ROM:
+
+            # Reshape to matrix form
+            N_V = self.N_V
+            approximation = approximation.reshape((N_V, N_V))
+
+        else:
+            # Convert to CSR format for fast algebraic operations
+            approximation = vector_to_csr(
+                entries=approximation,
+                rows=self.rows,
+                cols=self.cols,
+            )
+
+        return approximation

--- a/code/src/romtime/utils.py
+++ b/code/src/romtime/utils.py
@@ -46,7 +46,7 @@ def functional_to_array(operator):
     return array
 
 
-def bilinear_to_array(matrix):
+def bilinear_to_csr(matrix):
     """Return array from algebraic operator.
 
     Parameters
@@ -66,7 +66,27 @@ def bilinear_to_array(matrix):
     return array
 
 
-def matrix_to_vector(matrix):
+def project_csr(Ah, V):
+    """Project CSR matrix by basis matrix V.
+
+    A_N = VT Ah V
+
+    Parameters
+    ----------
+    Ah : scipy.sparse.csr_matrix
+    V : np.array
+        Basis matrix.
+
+    Returns
+    -------
+    AN : np.array
+    """
+    AhV = Ah.dot(V)
+    AN = np.matmul(V.T, AhV)
+    return AN
+
+
+def csr_to_vector(matrix):
     """Convert integrated bilinear form to vector.
 
     This means to keep only nonzero entries.
@@ -81,10 +101,26 @@ def matrix_to_vector(matrix):
     np.array
     """
 
-    csr_matrix = bilinear_to_array(matrix)
+    csr_matrix = bilinear_to_csr(matrix)
     rows, cols, vector = get_nonzero_entries(csr_matrix)
 
     return vector
+
+
+def vector_to_csr(entries, rows, cols):
+    """Convert vector matrix to CSR format.
+
+    Parameters
+    ----------
+    entries : np.array
+    rows : np.array
+    cols : np.array
+
+    Returns
+    -------
+    csr_matrix
+    """
+    return csr_matrix((entries, (rows, cols)))
 
 
 def round_parameters(sample, num=2):

--- a/code/tests/test_mdeim.py
+++ b/code/tests/test_mdeim.py
@@ -1,0 +1,233 @@
+from pprint import pprint
+
+import fenics
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from romtime.base import OneDimensionalSolver
+from romtime.parameters import get_uniform_dist
+from romtime.rom.mdeim import MatrixDiscreteEmpiricalInterpolation
+from romtime.utils import (
+    bilinear_to_csr,
+    functional_to_array,
+    get_nonzero_entries,
+    plot,
+)
+from sklearn.model_selection import ParameterSampler
+
+DEGREES = [1, 2, 3, 4, 5]
+
+
+class MockSolver(OneDimensionalSolver):
+    def __init__(
+        self,
+        domain,
+        dirichlet,
+        degrees=1,
+    ) -> None:
+        super().__init__(
+            domain=domain,
+            dirichlet=dirichlet,
+            poly_type="P",
+            degrees=degrees,
+        )
+
+    def create_diffusion_coefficient(self, mu, t):
+        """Create non-linear diffusion term.
+
+        \\alpha(x) = \\alpha_0 (1 + \\varepsilon x^2)
+
+        Returns
+        -------
+        alpha : fenics.Expression
+        """
+
+        alpha_0 = mu["alpha_0"]
+        epsilon = mu["epsilon"]
+
+        alpha = fenics.Expression(
+            "alpha_0 * (1.0 + epsilon * x[0] * x[0]) * (1.0 + t*t)",
+            degree=2,
+            alpha_0=alpha_0,
+            epsilon=epsilon,
+            t=t,
+        )
+
+        return alpha
+
+    def assemble_stiffness(self, mu, t, entries=None):
+
+        # ---------------------------------------------------------------------
+        # Weak Formulation
+        # ---------------------------------------------------------------------
+        dot, dx, grad = fenics.dot, fenics.dx, fenics.grad
+        u, v = self.u, self.v
+
+        alpha = self.create_diffusion_coefficient(mu=mu, t=t)
+        Ah = alpha * dot(grad(u), grad(v)) * dx
+
+        if entries:
+            Ah_mat = self.assemble_local(Ah, entries=entries)
+        else:
+            bc = self.define_homogeneous_dirichlet_bc()
+            Ah_mat = self.assemble_operator(Ah, bc)
+
+        return Ah_mat
+
+    def assemble_mass(self, mu, t):
+        pass
+
+    def assemble_forcing(self, mu, t, dofs=None):
+        pass
+
+    def assemble_lifting(self, mu, t):
+        pass
+
+
+@pytest.fixture
+def problem_definition():
+
+    domain = {"L": fenics.Constant(1.0), "nx": 100, "T": 5.0, "nt": 100}
+
+    #  Boundary conditions
+    b0 = "(1.0 - exp(- beta * t))"
+    bL = "(1.0 - exp(- beta * t)) * (1.0 + delta*delta * L * L)"
+
+    # TODO: This could be computed with sympy
+    # but I don't need this overhead for the moment
+    db0_dt = "beta * exp(- beta * t)"
+    dbL_dt = "(beta * exp(- beta * t)) * (1.0 + delta*delta * L * L)"
+
+    boundary_conditions = {"b0": b0, "bL": bL, "db0_dt": db0_dt, "dbL_dt": dbL_dt}
+
+    # Forcing term
+    forcing_term = """beta * exp(- beta * t) * (1.0 + delta * delta * x[0] * x[0]) - 2.0 * delta * delta * alpha_0 * (1.0 - exp(- beta * t))"""
+
+    return domain, boundary_conditions, forcing_term
+
+
+@pytest.fixture
+def grid():
+
+    _grid = {
+        "delta": get_uniform_dist(min=0.01, max=2.0),
+        "beta": get_uniform_dist(min=1.0, max=10.0),
+        "alpha_0": get_uniform_dist(min=0.01, max=2.0),
+        "epsilon": [0.0],
+    }
+
+    return _grid
+
+
+@pytest.fixture
+def sampler(grid):
+
+    rng = np.random.RandomState(0)
+    sampler = ParameterSampler(param_distributions=grid, n_iter=50, random_state=rng)
+
+    return sampler
+
+
+@pytest.mark.parametrize("degrees", DEGREES)
+def test_local_assembler_complete_operator(problem_definition, sampler, degrees):
+
+    domain, dirichlet, _ = problem_definition
+
+    domain["nx"] = 100
+
+    solver = MockSolver(domain=domain, dirichlet=dirichlet, degrees=degrees)
+    solver.setup()
+
+    mus = list(sampler)
+    mu = mus[0]
+    t = 5.0
+
+    Ah = solver.assemble_stiffness(mu=mu, t=t)
+    Ah = bilinear_to_csr(Ah)
+
+    rows, cols, entries = get_nonzero_entries(Ah)
+
+    idx = list(zip(rows, cols))
+    check = solver.assemble_stiffness(mu=mu, t=t, entries=idx)
+
+    #  Apply boundary conditions
+    boundary_value = 1.0
+    mask_ones = np.isclose(entries, boundary_value)
+    check[mask_ones] = boundary_value
+
+    assert_allclose(entries, check)
+
+
+def test_mdeim_tree_walk(problem_definition, grid):
+
+    domain, dirichet, _ = problem_definition
+    domain["nx"] = 5
+
+    solver = MockSolver(domain=domain, dirichlet=dirichet)
+    solver.setup()
+
+    ts = np.linspace(0, 5.0, 20)
+    tree_walk = {"ts": ts, "num_snapshots": 50}
+    Ah_mdeim = MatrixDiscreteEmpiricalInterpolation(
+        assemble=solver.assemble_stiffness, tree_walk_params=tree_walk, grid=grid
+    )
+
+    rnd = np.random.RandomState(0)
+    Ah_mdeim.setup(rnd=rnd)
+    Ah_mdeim.run()
+
+    #  -------------------------------------------------------------------------
+    # Assemble with a used parameter
+    #  -------------------------------------------------------------------------
+    mu = Ah_mdeim.mu_space[Ah_mdeim.OFFLINE][0]
+    print("Train mu:")
+    pprint(mu)
+    expected = solver.assemble_stiffness(mu=mu, t=1.0)
+    expected = bilinear_to_csr(expected)
+    expected.eliminate_zeros()
+    expected = expected.data
+
+    approximation = Ah_mdeim.interpolate(mu=mu, t=1.0)
+    approximation = approximation.data
+
+    # Apply boundary conditions
+    boundary_value = 1.0
+    mask_ones = np.isclose(expected, boundary_value)
+    approximation[mask_ones] = boundary_value
+
+    assert_allclose(expected, approximation)
+
+    #  -------------------------------------------------------------------------
+    # Assemble with an unseen parameter
+    #  -------------------------------------------------------------------------
+    rng = np.random.RandomState(19219)
+    test_sampler = ParameterSampler(
+        param_distributions=grid,
+        n_iter=50,
+        random_state=rng,
+    )
+
+    test_sampler = list(test_sampler)
+
+    mu = test_sampler[0]
+
+    print("Test mu:")
+    pprint(mu)
+
+    # Assemble full array
+    expected = solver.assemble_stiffness(mu=mu, t=1.0)
+    expected = bilinear_to_csr(expected)
+    expected.eliminate_zeros()
+    expected = expected.data
+
+    approximation = Ah_mdeim.interpolate(mu=mu, t=1.0)
+    approximation = approximation.data
+
+    # Apply boundary conditions
+    approximation[mask_ones] = boundary_value
+
+    assert_allclose(expected, approximation)
+
+    Ah_mdeim.evaluate(num=50, ts=tree_walk["ts"])
+
+    pass


### PR DESCRIPTION
Complete hyperreduction of MFP-1

* ENH: Matrix local assembly done!
* ENH, TST: Finish MDEIM implementation
* TST, CLN: Parametrized FEM degrees for (M)DEIM local assembly testing

Fixes: #19 #23 

I was worried about the BCs, they are not being honoured by the basis matrices,
because the snapshots are take averaged values at the Dirichlet entries.

This is not a problem because the ROM basis, built with the homogeneous BCs,
takes zero values at the boundaries, cancelling any misbehaving entry value.